### PR TITLE
Allow ranges in port mappings.

### DIFF
--- a/vhdl/vhdl.g4
+++ b/vhdl/vhdl.g4
@@ -696,6 +696,7 @@ formal_parameter_list
 
 formal_part
   : identifier
+   | identifier LPAREN explicit_range  RPAREN 
   ;
 
 free_quantity_declaration


### PR DESCRIPTION
I had the following vhdl  which failed to parse. 

seven_seg_led_instance : seven_seg_led port map (
  mclk=>mclk,
  an(3 downto 0)=>an(3 downto 0),
  seg(6 downto 0)=>seg(6 downto 0),
  dp=>dp
);

I believe it is valid vhdl (it synthesizes ok). 

This patch fixed everything for me.